### PR TITLE
Add more colors to palette.py

### DIFF
--- a/code_data_science/palette.py
+++ b/code_data_science/palette.py
@@ -70,15 +70,6 @@ __moderneColorMap = {
     'black': {
         100: '#1e1e1e',
         800: '#121212'
-    },
-    'magenta': {
-        'main': '#db4197'
-    },
-    'periwinkle': {
-        'main': '#7e9bd3'
-    },
-    'mint': {
-        'main': '#d6ffe2'
     }
 }
 
@@ -99,7 +90,7 @@ def qualitative(number: int = 0):
             __moderneColorMap['yellow']['main'],
             __moderneColorMap['green']['main'],
             __moderneColorMap['indigo']['main'],
-            __moderneColorMap['magenta']['main'],
-            __moderneColorMap['periwinkle']['main'],
-            __moderneColorMap['mint']['main'],
+            '#db4197', # magenta
+            '#7e9bd3', # periwinkle
+            '#d6ffe2', # mint
         ]

--- a/code_data_science/palette.py
+++ b/code_data_science/palette.py
@@ -70,6 +70,15 @@ __moderneColorMap = {
     'black': {
         100: '#1e1e1e',
         800: '#121212'
+    },
+    'magenta': {
+        'main': '#db4197'
+    },
+    'periwinkle': {
+        'main': '#7e9bd3'
+    },
+    'mint': {
+        'main': '#d6ffe2'
     }
 }
 
@@ -90,4 +99,7 @@ def qualitative(number: int = 0):
             __moderneColorMap['yellow']['main'],
             __moderneColorMap['green']['main'],
             __moderneColorMap['indigo']['main'],
+            __moderneColorMap['magenta']['main'],
+            __moderneColorMap['periwinkle']['main'],
+            __moderneColorMap['mint']['main'],
         ]


### PR DESCRIPTION
Based on `Moderne.BrandGuides.Color_May 2023.pdf`, for use in bar charts such as
https://github.com/moderneinc/moderne-visualizations-misc/blob/main/moderne_visualizations_misc/maven_parent_poms.ipynb, which now sometimes run out of colors to show, and then repeat previous colors.
![image](https://github.com/moderneinc/code-data-science/assets/1027334/5bd56c15-ad21-4df0-abdc-11a6c7654383)
