### PR TITLE
Utilize version selectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # @see https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "code_data_science"
-version = "2.1.2"
+version = "2.1.3"
 description = "A python implementation of various tools used in code data science."
 authors = [
     { name = "Jonathan Schneider", email = "jonathan@moderne.io" },
     { name = "Kyle Scully", email = "kyle@moderne.io" }
 ]
 license = { text = "Apache-2.0" }
-dependencies = ["pandas==2.0.3", "ipython==8.13.0"]
+dependencies = ["pandas>=2.0.3", "ipython>=8.13.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/moderneinc/code-data-science"


### PR DESCRIPTION
Following Python best practices, libraries should utilize version selectors while applications should use pinned dependencies. 