### PR TITLE
Strip comment lines from CSV before parsing

### DIFF
--- a/code_data_science/data_table.py
+++ b/code_data_science/data_table.py
@@ -1,5 +1,6 @@
 import os
 import csv
+from io import StringIO
 
 from typing import Union
 
@@ -9,5 +10,14 @@ from pandas import DataFrame
 FilePath = Union[str, "PathLike[str]"]
 
 
+def _strip_comments(filepath: FilePath) -> StringIO:
+    # pandas comment="#" strips both whole lines and inline occurrences, even inside quoted cells,
+    # so it would break cells containing code with #
+    with open(filepath, 'r') as f:
+        lines = [line for line in f if not line.lstrip().startswith('#')]
+    return StringIO(''.join(lines))
+
+
 def read_csv(sample: FilePath, *args, **kwargs) -> DataFrame:
-    return pd.read_csv(os.environ.get('NB_DATA_TABLE', sample), on_bad_lines='skip', skip_blank_lines=True, quoting=csv.QUOTE_ALL, *args, **kwargs)
+    source = _strip_comments(os.environ.get('NB_DATA_TABLE', sample))
+    return pd.read_csv(source, on_bad_lines='skip', skip_blank_lines=True, quoting=csv.QUOTE_ALL, *args, **kwargs)


### PR DESCRIPTION
## Summary
- Pre-filter lines starting with `#` before passing to pandas, so CSV files can contain comment lines
- Uses in-memory filtering rather than `pd.read_csv(comment="#")` since the pandas `comment` argument strips both whole lines and inline occurrences, even inside quoted cells — which would break cells containing code with `#`

## Test plan
- [ ] Verify CSVs with `#` comment lines are parsed correctly with comments removed
- [ ] Verify cells containing `#` in code examples are preserved