### PR TITLE
feat: trusted publishing, uv, and semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
       contents: write
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --group ci --python 3.9

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,52 @@
 name: Publish to PyPI
 
-# on manually trigger
 on:
   workflow_dispatch:
+    inputs:
+      scope:
+        description: Release scope
+        required: true
+        default: minor
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-          pip install twine
+          fetch-depth: 0
 
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group ci --python 3.9
+
+      - name: Bump version and commit change
         run: |
+          source .venv/bin/activate
+          semantic-release version --${{ github.event.inputs.scope }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: |
+          source .venv/bin/activate
           python -m build
-          python -m twine upload dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,16 +32,12 @@ jobs:
         run: uv sync --group ci --python 3.9
 
       - name: Bump version and commit change
-        run: |
-          source .venv/bin/activate
-          semantic-release version --${{ github.event.inputs.scope }}
+        run: uv run semantic-release version --${{ github.event.inputs.scope }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: |
-          source .venv/bin/activate
-          python -m build
+        run: uv run python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,14 @@ authors = [
     { name = "Kyle Scully", email = "kyle@moderne.io" }
 ]
 license = { text = "Apache-2.0" }
+requires-python = ">=3.9"
 dependencies = ["pandas>=2.0.3", "ipython>=8.13.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/moderneinc/code-data-science"
+
+[dependency-groups]
+ci = ["python-semantic-release", "build"]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]


### PR DESCRIPTION
## Summary
- Replace twine + `PYPI_TOKEN` secret with PyPI trusted publishing (OIDC) via `pypa/gh-action-pypi-publish`
- Add `python-semantic-release` for automatic version bumping with major/minor/patch scope selector
- Switch CI from pip to `uv` for dependency management
- Bump Python from 3.8 to 3.9, update `actions/setup-python` to v5

## Setup required
- [ ] Create `release` environment in GitHub repo settings
- [ ] Add trusted publisher on PyPI (Owner: `moderneinc`, Repo: `code-data-science`, Workflow: `publish.yml`, Environment: `release`)
- [ ] Remove `PYPI_TOKEN` secret after verifying trusted publishing works